### PR TITLE
feat: enforce Release branch protection with GitHub Action

### DIFF
--- a/.github/workflows/enforce-release-source.yml
+++ b/.github/workflows/enforce-release-source.yml
@@ -1,0 +1,17 @@
+name: Enforce Release Source Branch
+
+on:
+  pull_request:
+    branches: [Release]
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR comes from Development
+        run: |
+          if [ "${{ github.head_ref }}" != "Development" ]; then
+            echo "::error::PRs to Release must come from Development. Source branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "Source branch is Development. OK."


### PR DESCRIPTION
Adds a GitHub Actions workflow that blocks PRs to Release unless they come from Development. Branch protection on Release now requires this check to pass.